### PR TITLE
(Fixes #1) Multiple Authorable Theme Folder generates bad docker-compose file

### DIFF
--- a/scripts/docker-build.js
+++ b/scripts/docker-build.js
@@ -32,11 +32,11 @@ function populateArg(path) {
 }
 
 function populateThemes() {
-	const themes = packageJs.keycloak.themes.map(({dir, name}) => `- "${dir}:/opt/jboss/keycloak/themes/${name}"`);
+	const themes = packageJs.keycloak.themes.map(({dir, name}) => `      - "${dir}:/opt/jboss/keycloak/themes/${name}"`);
 	replace.sync({
 		files:`./docker-compose.yml`,
 		from:`%volumes%`,
-		to:themes.length > 0 ? 'volumes:\n    ' + themes.join('\n      ') : ''
+		to:themes.length > 0 ? 'volumes:\n' + themes.join('\n') : ''
 	});
 }
 


### PR DESCRIPTION
Fixed the way the authorable themes are written to docker volumes in the docker-compose file.