### PR TITLE
Build and Copy SPIs on `npm start`

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,16 +22,15 @@
 		"docker:build": "node scripts/docker-build.js",
 		"docker:down": "docker-compose down",
 		"docker:up": "docker-compose up",
-
 		"keycloak:updateDeployments": "node scripts/keycloak-updateDeployments.js",
 		"keycloak:updateThemes": "node scripts/keycloak-updateThemes.js",
-		"keycloak:buildSPIs": "node scripts/keycloak-buildSPIs.js",
-		"keycloak:update":"npm run keycloak:updateDeployments; npm run keycloak:updateThemes; npm run keycloak:buildSPIs",
-
+		"keycloak:spi:build": "node scripts/keycloak-spi-build.js",
+		"keycloak:update": "npm run keycloak:updateDeployments; npm run keycloak:updateThemes; npm run keycloak:spi:build",
 		
+		"external": "node ./src/external-website/index.js",
 		"start": "npm run docker:build; npm run docker:up",
 		"stop": "npm run docker:down",
-		"update":"npm run keycloak:update"
+		"update": "npm run keycloak:update"
 	},
 	"devDependencies": {
 		"copyfiles": "^2.4.0",

--- a/scripts/keycloak-spi-build.js
+++ b/scripts/keycloak-spi-build.js
@@ -1,0 +1,2 @@
+const { build, copy } = require('./keycloak-spi-util');
+build().then(() => copy());

--- a/scripts/keycloak-spi-util.js
+++ b/scripts/keycloak-spi-util.js
@@ -21,9 +21,15 @@ function findArtifacts() {
 	return [];
 }
 
-function copyArtifactsToDocker(artifacts) {
+function copy() {
+	const artifacts = findArtifacts();
 	const r = Promise.resolve(true);
 	return artifacts.reduce((p, artifact) => p.then(() => exec(`docker cp ${artifact} ${config.keycloak.container.name}:/opt/jboss/keycloak/standalone/deployments/`)), r);
 }
 
-build().then(() => copyArtifactsToDocker(findArtifacts()));
+function getDockerFileCopy() {
+	const artifacts = findArtifacts();
+	return artifacts.reduce((r, artifact) => r + `COPY ${artifact} /opt/jboss/keycloak/standalone/deployments/\n`, '');
+}
+
+module.exports = { build, copy, getDockerFileCopy };

--- a/scripts/resources/docker/Dockerfile
+++ b/scripts/resources/docker/Dockerfile
@@ -4,6 +4,9 @@ FROM jboss/keycloak
 COPY keycloak/modules/ /opt/jboss/keycloak/modules/system/layers/keycloak/
 COPY keycloak/standalone/deployments/ /opt/jboss/keycloak/standalone/deployments/
 
+# Add Authorable SPIs:
+%spis%
+
 # Add pre-installed themes: 
 COPY keycloak/themes/ /opt/jboss/keycloak/themes/
 


### PR DESCRIPTION
Authorable SPIs are now built and copied in on `npm start`